### PR TITLE
replace include module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 - name: 'include os-specific vars'
-  include_vars: "{{ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ansible_os_family | lower }}.yml"
   tags:
     - 'chrony'
     - 'chrony-vars'
 
-- include: "install.yml"
-- include: "configure.yml"
-- include: "service.yml"
+- name: Include install tasks
+  ansible.builtin.include_tasks: "install.yml"
+- name: Include configuration tasks
+  ansible.builtin.include_tasks: "configure.yml"
+- name: Include the systemd service tasks
+  ansible.builtin.include_tasks: "service.yml"


### PR DESCRIPTION
deprecated in ansible 2.16
needed by:
- https://github.com/usegalaxy-eu/issues/issues/492